### PR TITLE
Allow for faster reboot cycles and fully tuning all available options at run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ Role Variables
 
 The variables that can be passed to this role with default values are as follows.
 
-    # number of minutes to wait before next server reboot
-    rolling_reboot_pause: 1
+    # number of seconds to wait before next server reboot
+    rolling_reboot_pause: 60
     
     # by default wait for ssh daemon after reboot
+    # listen to a service port that is meaningful in your environment
+    # thus allowing you to reduce the value for rolling_reboot_pause
     rolling_reboot_wait_port: 22
+
+    # number of seconds to wait before polling port
+    # in some environments that can be set rather low (10 seconds or less)
+    rolling_reboot_wait_delay: 60
 
 Dependencies
 ------------
@@ -40,7 +46,10 @@ Example Playbook
 
 3. Execute the the playbook
 
-        ansible-playbook -i hosts rolling_reboot.yml -e "rolling_reboot_group=<group_name> rolling_reboot_wait_port=22"
+        ansible-playbook -i hosts rolling_reboot.yml -e 'rolling_reboot_group=<your group> \
+                                                         rolling_reboot_wait_port=8087 \
+                                                         rolling_reboot_wait_delay=10 \
+                                                         rolling_reboot_pause=10 '
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for ansible-rolling-reboot playbook
 
-# number of minutes to wait before next server reboot
-rolling_reboot_pause: 1
+# number of seconds to wait before next server reboot
+rolling_reboot_pause: 30
 
 # by default wait for ssh daemon after reboot
 rolling_reboot_wait_port: 22
@@ -11,5 +11,5 @@ rolling_reboot_wait_port: 22
 
 _rolling_reboot:
 
-  # wait 60 seconds before starting to poll
-  wait_delay: 60
+  # wait 30 seconds before starting to poll
+  wait_delay: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,14 +2,10 @@
 # defaults file for ansible-rolling-reboot playbook
 
 # number of seconds to wait before next server reboot
-rolling_reboot_pause: 30
+rolling_reboot_pause: 60
 
 # by default wait for ssh daemon after reboot
 rolling_reboot_wait_port: 22
 
-### Constants
-
-_rolling_reboot:
-
-  # wait 30 seconds before starting to poll
-  wait_delay: 30
+# wait 60 seconds before starting to poll
+rolling_reboot_wait_delay: 60

--- a/files/helper/reboot-soon.sh
+++ b/files/helper/reboot-soon.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -i
+
+( ( sleep 5 ; /sbin/reboot --force --reboot ) & ) &
+[ "$0" == "/tmp/reboot-soon.sh" ] && rm -f /tmp/reboot-soon.sh
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   tags: reboot
 
 - name: waiting for port after reboot
-  wait_for: host={{ inventory_hostname }} port={{ rolling_reboot_wait_port }} delay={{ rolling_reboot.wait_delay }} state=started
+  wait_for: host={{ inventory_hostname }} port={{ rolling_reboot_wait_port }} delay={{ rolling_reboot_wait_delay }} state=started
   connection: local
   sudo: false
   tags: reboot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
 # This role conains tasks for servers reboot in rolling manner
 
+- name: copy helper script
+  copy: src=helper/reboot-soon.sh dest=/tmp/reboot-soon.sh mode=755
+
 - name: rebooting server
-  command: /sbin/shutdown -r now
+  command: /tmp/reboot-soon.sh &
   tags: reboot
 
 - name: waiting for port after reboot
@@ -12,5 +15,5 @@
   tags: reboot
 
 - name: pausing
-  pause: minutes={{ rolling_reboot_pause }}
+  pause: seconds={{ rolling_reboot_pause }}
   tags: reboot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   tags: reboot
 
 - name: waiting for port after reboot
-  wait_for: host={{ inventory_hostname }} port={{ rolling_reboot_wait_port }} delay={{ _rolling_reboot.wait_delay }} state=started
+  wait_for: host={{ inventory_hostname }} port={{ rolling_reboot_wait_port }} delay={{ rolling_reboot.wait_delay }} state=started
   connection: local
   sudo: false
   tags: reboot


### PR DESCRIPTION
1) Address tearing down of ssh connections being fatal in Centos 7, completely preventing use of this playbook, the workaround is to completely detach the reboot command from ansible 

2) Allow full configuration of ansible variables to adjust wait / cycle times to what works in individual environments
